### PR TITLE
fix: gitlab 12.9 import with the add of path validator in gitlab side

### DIFF
--- a/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
@@ -172,9 +172,13 @@ public class GitlabFetcher implements FilesFetcher {
 
             switch (gitlabFetcherConfiguration.getApiVersion()) {
                 case V4:
+                    String filepath = gitlabFetcherConfiguration.getFilepath().trim();
+                    if (filepath.startsWith("/")) {
+                        filepath = filepath.substring(1);
+                    }
                     return gitlabFetcherConfiguration.getGitlabUrl().trim()
                             + "/projects/" + encodedProject
-                            + "/repository/files/" + URLEncoder.encode(gitlabFetcherConfiguration.getFilepath().trim(), "UTF-8")
+                            + "/repository/files/" + URLEncoder.encode(filepath, "UTF-8")
                             + "?ref=" + ref;
                 default:
                     return gitlabFetcherConfiguration.getGitlabUrl().trim()

--- a/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcher_FetchTest.java
+++ b/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcher_FetchTest.java
@@ -56,7 +56,7 @@ public class GitlabFetcher_FetchTest {
 
     @Test
     public void shouldNotFetchWithoutContent() throws FetcherException {
-        stubFor(get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files/%2Fpath%2Fto%2Ffile?ref=sha1"))
+        stubFor(get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody("{\"key\": \"value\"}")));
@@ -67,6 +67,7 @@ public class GitlabFetcher_FetchTest {
         config.setGitlabUrl(wireMockRule.baseUrl() + "/api/v3");
         config.setBranchOrTag("sha1");
         config.setPrivateToken("token");
+        config.setApiVersion(ApiVersion.V3);
         ReflectionTestUtils.setField(fetcher, "gitlabFetcherConfiguration", config);
         ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
 
@@ -77,7 +78,7 @@ public class GitlabFetcher_FetchTest {
 
     @Test
     public void shouldNotFetchEmptyBody() throws Exception {
-        stubFor(get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files/%2Fpath%2Fto%2Ffile?ref=sha1"))
+        stubFor(get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1"))
                 .willReturn(aResponse()
                         .withStatus(200)));
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
@@ -87,6 +88,7 @@ public class GitlabFetcher_FetchTest {
         config.setGitlabUrl(wireMockRule.baseUrl() + "/api/v3");
         config.setBranchOrTag("sha1");
         config.setPrivateToken("token");
+        config.setApiVersion(ApiVersion.V3);
         ReflectionTestUtils.setField(fetcher, "gitlabFetcherConfiguration", config);
         ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
 
@@ -107,6 +109,7 @@ public class GitlabFetcher_FetchTest {
         config.setGitlabUrl(wireMockRule.baseUrl() + "/api/v3");
         config.setBranchOrTag("sha1");
         config.setPrivateToken("token");
+        config.setApiVersion(ApiVersion.V3);
         ReflectionTestUtils.setField(fetcher, "gitlabFetcherConfiguration", config);
 
         fetcher.fetch();
@@ -119,7 +122,7 @@ public class GitlabFetcher_FetchTest {
         String content = "Gravitee.io is awesome!";
         String encoded = Base64.getEncoder().encodeToString(content.getBytes());
 
-        stubFor(get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files/%2Fpath%2Fto%2Ffile?ref=sha1"))
+        stubFor(get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody("{\"content\": \""+encoded+"\"}")));
@@ -130,6 +133,7 @@ public class GitlabFetcher_FetchTest {
         config.setGitlabUrl(wireMockRule.baseUrl() + "/api/v3");
         config.setBranchOrTag("sha1");
         config.setPrivateToken("token");
+        config.setApiVersion(ApiVersion.V3);
         ReflectionTestUtils.setField(fetcher, "gitlabFetcherConfiguration", config);
         ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
 
@@ -148,7 +152,7 @@ public class GitlabFetcher_FetchTest {
         String content = "Gravitee.io is awesome!";
         String encoded = Base64.getEncoder().encodeToString(content.getBytes());
 
-        stubFor(get(urlEqualTo("/api/v4/projects/namespace%2Fproject/repository/files/%2Fpath%2Fto%2Ffile?ref=sha1"))
+        stubFor(get(urlEqualTo("/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Ffile?ref=sha1"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withBody("{\"content\": \""+encoded+"\"}")));
@@ -191,6 +195,7 @@ public class GitlabFetcher_FetchTest {
         config.setGitlabUrl(wireMockRule.baseUrl() + "/api/v3");
         config.setBranchOrTag("sha1");
         config.setPrivateToken("token");
+        config.setApiVersion(ApiVersion.V3);
         ReflectionTestUtils.setField(fetcher, "gitlabFetcherConfiguration", config);
 
         try {

--- a/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcher_TreeTest.java
+++ b/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcher_TreeTest.java
@@ -71,6 +71,7 @@ public class GitlabFetcher_TreeTest {
         config.setGitlabUrl("http://localhost:" + wireMockRule.port() + "/api/v3");
         config.setBranchOrTag("sha1");
         config.setPrivateToken("token");
+        config.setApiVersion(ApiVersion.V3);
         ReflectionTestUtils.setField(fetcher, "gitlabFetcherConfiguration", config);
         ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
 
@@ -91,6 +92,7 @@ public class GitlabFetcher_TreeTest {
         config.setGitlabUrl("http://localhost:" + wireMockRule.port() + "/api/v3");
         config.setBranchOrTag("sha1");
         config.setPrivateToken("token");
+        config.setApiVersion(ApiVersion.V3);
         ReflectionTestUtils.setField(fetcher, "gitlabFetcherConfiguration", config);
         ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
 
@@ -117,6 +119,7 @@ public class GitlabFetcher_TreeTest {
         config.setGitlabUrl("http://localhost:" + wireMockRule.port() + "/api/v3");
         config.setBranchOrTag("sha1");
         config.setPrivateToken("token");
+        config.setApiVersion(ApiVersion.V3);
         ReflectionTestUtils.setField(fetcher, "gitlabFetcherConfiguration", config);
         ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
 
@@ -145,6 +148,7 @@ public class GitlabFetcher_TreeTest {
         config.setGitlabUrl("http://localhost:" + wireMockRule.port() + "/api/v3");
         config.setBranchOrTag("sha1");
         config.setPrivateToken("token");
+        config.setApiVersion(ApiVersion.V3);
         ReflectionTestUtils.setField(fetcher, "gitlabFetcherConfiguration", config);
         ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
 
@@ -170,6 +174,7 @@ public class GitlabFetcher_TreeTest {
         config.setGitlabUrl("http://localhost:" + wireMockRule.port() + "/api/v3");
         config.setBranchOrTag("sha1");
         config.setPrivateToken("token");
+        config.setApiVersion(ApiVersion.V3);
         ReflectionTestUtils.setField(fetcher, "gitlabFetcherConfiguration", config);
         ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
 


### PR DESCRIPTION
Fix issue : https://github.com/gravitee-io/issues/issues/3677

Since gitlab 12.9 file_path is validated by gitlab in the API.

Gitlab Link: 
* https://gitlab.com/gitlab-org/gitlab/-/merge_requests/24223
* https://gitlab.com/gitlab-org/gitlab/-/issues/33768
* https://gitlab.com/gitlab-org/gitlab/-/commit/ae2235c8deb964187a39268ccaedaa573d47e814

