### PR TITLE
Fix encoded URL + Namespace no longer required

### DIFF
--- a/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
@@ -156,7 +156,6 @@ public class GitlabFetcher implements FilesFetcher {
         if (gitlabFetcherConfiguration.getBranchOrTag() == null || gitlabFetcherConfiguration.getBranchOrTag().isEmpty()
                 || gitlabFetcherConfiguration.getGitlabUrl() == null || gitlabFetcherConfiguration.getGitlabUrl().isEmpty()
                 || (checkFilepath && (gitlabFetcherConfiguration.getFilepath() == null || gitlabFetcherConfiguration.getFilepath().isEmpty()))
-                || gitlabFetcherConfiguration.getNamespace() == null || gitlabFetcherConfiguration.getNamespace().isEmpty()
                 || gitlabFetcherConfiguration.getProject() == null || gitlabFetcherConfiguration.getProject().isEmpty()
                 || (gitlabFetcherConfiguration.isAutoFetch() && (gitlabFetcherConfiguration.getFetchCron() == null || gitlabFetcherConfiguration.getFetchCron().isEmpty()))
         ) {
@@ -178,7 +177,9 @@ public class GitlabFetcher implements FilesFetcher {
                 : gitlabFetcherConfiguration.getBranchOrTag().trim());
 
         try {
-            String encodedProject = URLEncoder.encode(gitlabFetcherConfiguration.getNamespace().trim() + '/' + gitlabFetcherConfiguration.getProject().trim(), "UTF-8");
+            String encodedProject = URLEncoder.encode(gitlabFetcherConfiguration.getNamespace().trim(), "UTF-8")
+                    + '/'
+                    + URLEncoder.encode(gitlabFetcherConfiguration.getProject().trim(), "UTF-8");
 
             switch (gitlabFetcherConfiguration.getApiVersion()) {
                 case V4:
@@ -209,7 +210,9 @@ public class GitlabFetcher implements FilesFetcher {
                 : gitlabFetcherConfiguration.getBranchOrTag().trim());
 
         try {
-            String encodedProject = URLEncoder.encode(gitlabFetcherConfiguration.getNamespace().trim() + '/' + gitlabFetcherConfiguration.getProject().trim(), "UTF-8");
+            String encodedProject = URLEncoder.encode(gitlabFetcherConfiguration.getNamespace().trim(), "UTF-8")
+                    + '/'
+                    + URLEncoder.encode(gitlabFetcherConfiguration.getProject().trim(), "UTF-8");
             String filepath = gitlabFetcherConfiguration.getFilepath().trim();
 
             if (filepath.startsWith("/")) {

--- a/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcherConfiguration.java
+++ b/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcherConfiguration.java
@@ -29,7 +29,7 @@ public class GitlabFetcherConfiguration implements FetcherConfiguration, Filepat
 
     private String gitlabUrl;
     private boolean useSystemProxy;
-    private String namespace;
+    private String namespace = "";
     private String project;
     private String branchOrTag;
     private String filepath;

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -60,7 +60,6 @@
   },
   "required": [
     "gitlabUrl",
-    "namespace",
     "project",
     "branchOrTag",
     "privateToken"


### PR DESCRIPTION
## Quick fixes
* Remove the wrong UTF-8 encoding of the generated path of the generated GitLab API URL `...projects/<namespace>/<project_id>...` when configuring a documentation for an API with the GitLab fetcher.
* Make the namespace no longer required (in several use cases there is no namespace). In that case the URL is `...projects//<project_id>...` but it works anyway.