### PR TITLE
feat: upgrade to vertx 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.17.0
+    gravitee: gravitee-io/gravitee@5.10.2
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,3 @@
+lombok.addLombokGeneratedAnnotation = true
+config.stopBubbling = true
+lombok.log.custom.declaration = org.slf4j.Logger io.gravitee.node.logging.NodeLoggerFactory.getLogger(TYPE)

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
             <version>${gravitee-node.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-logging</artifactId>
+            <version>${gravitee-node.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Jackson dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.6.0</version>
+        <version>24.0.2</version>
     </parent>
 
     <groupId>io.gravitee.fetcher</groupId>
@@ -34,8 +34,8 @@
     <name>Gravitee.io APIM - Fetcher - GitLab</name>
 
     <properties>
-        <gravitee-bom.version>6.0.62</gravitee-bom.version>
-        <gravitee-node-api.version>4.8.9</gravitee-node-api.version>
+        <gravitee-bom.version>9.0.2</gravitee-bom.version>
+        <gravitee-node.version>9.2.1</gravitee-node.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <wiremock.version>3.13.2</wiremock.version>
 
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
-            <version>${gravitee-node-api.version}</version>
+            <version>${gravitee-node.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
@@ -40,6 +40,7 @@ import java.net.URLEncoder;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -299,7 +300,9 @@ public class GitlabFetcher implements FilesFetcher {
             .setTrustAll(true)
             .setKeepAlive(false)
             .setTcpKeepAlive(false)
-            .setConnectTimeout(httpClientTimeout);
+            .setConnectTimeout(httpClientTimeout)
+            .setIdleTimeout(httpClientTimeout)
+            .setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
 
         final PoolOptions poolOptions = new PoolOptions().setHttp1MaxSize(1);
 

--- a/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
@@ -182,7 +182,7 @@ public class GitlabFetcher implements FilesFetcher {
             throw new FetcherException("Some required configuration attributes are missing.", null);
         }
 
-        if (gitlabFetcherConfiguration.isAutoFetch() && gitlabFetcherConfiguration.getFetchCron() != null) {
+        if (gitlabFetcherConfiguration.isAutoFetch()) {
             try {
                 CronExpression.parse(gitlabFetcherConfiguration.getFetchCron());
             } catch (IllegalArgumentException e) {
@@ -355,23 +355,7 @@ public class GitlabFetcher implements FilesFetcher {
             httpClient
                 .request(reqOptions)
                 .compose(HttpClientRequest::send)
-                .compose(response -> {
-                    if (response.statusCode() == HttpStatusCode.OK_200) {
-                        return response.body();
-                    } else {
-                        return Future.failedFuture(
-                            new FetcherException(
-                                "Unable to fetch '" +
-                                    url +
-                                    "'. Status code: " +
-                                    response.statusCode() +
-                                    ". Message: " +
-                                    response.statusMessage(),
-                                null
-                            )
-                        );
-                    }
-                })
+                .compose(response -> handleResponse(url, response))
                 .onSuccess(promise::complete)
                 .onFailure(promise::fail);
         } catch (Exception ex) {
@@ -379,5 +363,18 @@ public class GitlabFetcher implements FilesFetcher {
         }
 
         return promise.future().toCompletionStage().toCompletableFuture();
+    }
+
+    private Future<Buffer> handleResponse(String url, HttpClientResponse response) {
+        if (response.statusCode() == HttpStatusCode.OK_200) {
+            return response.body();
+        } else {
+            return Future.failedFuture(
+                new FetcherException(
+                    "Unable to fetch '" + url + "'. Status code: " + response.statusCode() + ". Message: " + response.statusMessage(),
+                    null
+                )
+            );
+        }
     }
 }

--- a/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
@@ -282,6 +282,10 @@ public class GitlabFetcher implements FilesFetcher {
             }
 
             return new ObjectMapper().readTree(buffer.getBytes());
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            log.error("Fetch of Gitlab content '{}' has been interrupted", url, ie);
+            throw new FetcherException("Unable to fetch Gitlab content (" + ie.getMessage() + ")", ie);
         } catch (Exception ex) {
             Throwable cause = ex instanceof ExecutionException && ex.getCause() != null ? ex.getCause() : ex;
             log.error(cause.getMessage(), cause);

--- a/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
@@ -39,8 +39,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.support.CronExpression;
@@ -50,9 +49,8 @@ import org.springframework.scheduling.support.CronExpression;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class GitlabFetcher implements FilesFetcher {
-
-    private static final Logger logger = LoggerFactory.getLogger(GitlabFetcher.class);
 
     private static final String HTTPS_SCHEME = "https";
 
@@ -230,7 +228,7 @@ public class GitlabFetcher implements FilesFetcher {
                     );
             }
         } catch (UnsupportedEncodingException e) {
-            logger.error("Error thrown when trying to encode the url", e);
+            log.error("Error thrown when trying to encode the url", e);
             throw new FetcherException("Error thrown when trying to encode the url", e);
         }
     }
@@ -268,7 +266,7 @@ public class GitlabFetcher implements FilesFetcher {
                 "&per_page=100"
             );
         } catch (UnsupportedEncodingException e) {
-            logger.error("Error thrown when trying to encode the url", e);
+            log.error("Error thrown when trying to encode the url", e);
             throw new FetcherException("Error thrown when trying to encode the url", e);
         }
     }
@@ -277,13 +275,13 @@ public class GitlabFetcher implements FilesFetcher {
         try {
             Buffer buffer = fetchContent(url).get();
             if (buffer == null || buffer.length() == 0) {
-                logger.warn("Something goes wrong, Gitlab responds with a status 200 but the content is empty.");
+                log.warn("Something goes wrong, Gitlab responds with a status 200 but the content is empty.");
                 return null;
             }
 
             return new ObjectMapper().readTree(buffer.getBytes());
         } catch (Exception ex) {
-            logger.error(ex.getMessage(), ex);
+            log.error(ex.getMessage(), ex);
             throw new FetcherException("Unable to fetch Gitlab content (" + ex.getMessage() + ")", ex);
         }
     }
@@ -328,7 +326,7 @@ public class GitlabFetcher implements FilesFetcher {
 
         try {
             String pathAndQuery = requestUri.getRawPath() + (requestUri.getRawQuery() != null ? "?" + requestUri.getRawQuery() : "");
-            logger.debug("Fetching GitLab content from host: {}, URI: {}", requestUri.getHost(), pathAndQuery);
+            log.debug("Fetching GitLab content from host: {}, URI: {}", requestUri.getHost(), pathAndQuery);
             final RequestOptions reqOptions = new RequestOptions()
                 .setMethod(HttpMethod.GET)
                 .setPort(port)
@@ -368,7 +366,7 @@ public class GitlabFetcher implements FilesFetcher {
                 .onSuccess(promise::complete)
                 .onFailure(promise::fail);
         } catch (Exception ex) {
-            logger.error("Unable to fetch content using HTTP", ex);
+            log.error("Unable to fetch content using HTTP", ex);
             promise.fail(ex);
         }
 

--- a/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
@@ -26,7 +26,7 @@ import io.gravitee.fetcher.api.FilesFetcher;
 import io.gravitee.fetcher.api.Resource;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.utils.NodeUtils;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -176,10 +176,8 @@ public class GitlabFetcher implements FilesFetcher {
             gitlabFetcherConfiguration.getNamespace().isEmpty() ||
             gitlabFetcherConfiguration.getProject() == null ||
             gitlabFetcherConfiguration.getProject().isEmpty() ||
-            (
-                gitlabFetcherConfiguration.isAutoFetch() &&
-                (gitlabFetcherConfiguration.getFetchCron() == null || gitlabFetcherConfiguration.getFetchCron().isEmpty())
-            )
+            (gitlabFetcherConfiguration.isAutoFetch() &&
+                (gitlabFetcherConfiguration.getFetchCron() == null || gitlabFetcherConfiguration.getFetchCron().isEmpty()))
         ) {
             throw new FetcherException("Some required configuration attributes are missing.", null);
         }
@@ -194,12 +192,9 @@ public class GitlabFetcher implements FilesFetcher {
     }
 
     private String getFetchUrl() throws FetcherException {
-        String ref =
-            (
-                (gitlabFetcherConfiguration.getBranchOrTag() == null || gitlabFetcherConfiguration.getBranchOrTag().trim().isEmpty())
-                    ? "master"
-                    : gitlabFetcherConfiguration.getBranchOrTag().trim()
-            );
+        String ref = ((gitlabFetcherConfiguration.getBranchOrTag() == null || gitlabFetcherConfiguration.getBranchOrTag().trim().isEmpty())
+                ? "master"
+                : gitlabFetcherConfiguration.getBranchOrTag().trim());
 
         try {
             String encodedProject = URLEncoder.encode(
@@ -241,12 +236,9 @@ public class GitlabFetcher implements FilesFetcher {
     }
 
     private String getTreeUrl() throws FetcherException {
-        String ref =
-            (
-                (gitlabFetcherConfiguration.getBranchOrTag() == null || gitlabFetcherConfiguration.getBranchOrTag().trim().isEmpty())
-                    ? "master"
-                    : gitlabFetcherConfiguration.getBranchOrTag().trim()
-            );
+        String ref = ((gitlabFetcherConfiguration.getBranchOrTag() == null || gitlabFetcherConfiguration.getBranchOrTag().trim().isEmpty())
+                ? "master"
+                : gitlabFetcherConfiguration.getBranchOrTag().trim());
 
         try {
             String encodedProject = URLEncoder.encode(
@@ -305,10 +297,11 @@ public class GitlabFetcher implements FilesFetcher {
         final HttpClientOptions options = new HttpClientOptions()
             .setSsl(ssl)
             .setTrustAll(true)
-            .setMaxPoolSize(1)
             .setKeepAlive(false)
             .setTcpKeepAlive(false)
             .setConnectTimeout(httpClientTimeout);
+
+        final PoolOptions poolOptions = new PoolOptions().setHttp1MaxSize(1);
 
         if (gitlabFetcherConfiguration.isUseSystemProxy()) {
             ProxyOptions proxyOptions = new ProxyOptions();
@@ -327,7 +320,9 @@ public class GitlabFetcher implements FilesFetcher {
             options.setProxyOptions(proxyOptions);
         }
 
-        final HttpClient httpClient = vertx.createHttpClient(options);
+        final HttpClient httpClient = vertx.createHttpClient(options, poolOptions);
+        // Ensure the HTTP client is closed exactly once when the promise completes, regardless of success or failure
+        promise.future().onComplete(ar -> httpClient.close());
 
         final int port = requestUri.getPort() != -1 ? requestUri.getPort() : (HTTPS_SCHEME.equals(requestUri.getScheme()) ? 443 : 80);
 
@@ -352,70 +347,26 @@ public class GitlabFetcher implements FilesFetcher {
 
             httpClient
                 .request(reqOptions)
-                .onFailure(
-                    new Handler<Throwable>() {
-                        @Override
-                        public void handle(Throwable throwable) {
-                            promise.fail(throwable);
-
-                            // Close client
-                            httpClient.close();
-                        }
+                .compose(HttpClientRequest::send)
+                .compose(response -> {
+                    if (response.statusCode() == HttpStatusCode.OK_200) {
+                        return response.body();
+                    } else {
+                        return Future.failedFuture(
+                            new FetcherException(
+                                "Unable to fetch '" +
+                                    url +
+                                    "'. Status code: " +
+                                    response.statusCode() +
+                                    ". Message: " +
+                                    response.statusMessage(),
+                                null
+                            )
+                        );
                     }
-                )
-                .onSuccess(
-                    new Handler<HttpClientRequest>() {
-                        @Override
-                        public void handle(HttpClientRequest request) {
-                            request.response(asyncResponse -> {
-                                if (asyncResponse.failed()) {
-                                    promise.fail(asyncResponse.cause());
-
-                                    // Close client
-                                    httpClient.close();
-                                } else {
-                                    HttpClientResponse response = asyncResponse.result();
-                                    if (response.statusCode() == HttpStatusCode.OK_200) {
-                                        response.bodyHandler(buffer -> {
-                                            promise.complete(buffer);
-
-                                            // Close client
-                                            httpClient.close();
-                                        });
-                                    } else {
-                                        promise.fail(
-                                            new FetcherException(
-                                                "Unable to fetch '" +
-                                                url +
-                                                "'. Status code: " +
-                                                response.statusCode() +
-                                                ". Message: " +
-                                                response.statusMessage(),
-                                                null
-                                            )
-                                        );
-
-                                        // Close client
-                                        httpClient.close();
-                                    }
-                                }
-                            });
-
-                            request.exceptionHandler(throwable -> {
-                                try {
-                                    promise.fail(throwable);
-
-                                    // Close client
-                                    httpClient.close();
-                                } catch (IllegalStateException ise) {
-                                    // Do not take care about exception when closing client
-                                }
-                            });
-
-                            request.end();
-                        }
-                    }
-                );
+                })
+                .onSuccess(promise::complete)
+                .onFailure(promise::fail);
         } catch (Exception ex) {
             logger.error("Unable to fetch content using HTTP", ex);
             promise.fail(ex);

--- a/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
@@ -39,6 +39,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -281,8 +282,9 @@ public class GitlabFetcher implements FilesFetcher {
 
             return new ObjectMapper().readTree(buffer.getBytes());
         } catch (Exception ex) {
-            log.error(ex.getMessage(), ex);
-            throw new FetcherException("Unable to fetch Gitlab content (" + ex.getMessage() + ")", ex);
+            Throwable cause = ex instanceof ExecutionException && ex.getCause() != null ? ex.getCause() : ex;
+            log.error(cause.getMessage(), cause);
+            throw new FetcherException("Unable to fetch Gitlab content (" + cause.getMessage() + ")", cause);
         }
     }
 
@@ -366,7 +368,6 @@ public class GitlabFetcher implements FilesFetcher {
                 .onSuccess(promise::complete)
                 .onFailure(promise::fail);
         } catch (Exception ex) {
-            log.error("Unable to fetch content using HTTP", ex);
             promise.fail(ex);
         }
 

--- a/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcherTest.java
+++ b/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcherTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.fetcher.gitlab;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.gravitee.fetcher.api.FetcherException;
+import io.vertx.core.Vertx;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author GraviteeSource Team
+ */
+class GitlabFetcherTest {
+
+    @RegisterExtension
+    static WireMockExtension wiremock = WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+    private Vertx vertx;
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        vertx.close().toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void should_expose_original_cause_instead_of_async_wrapper_when_fetch_fails() {
+        wiremock.stubFor(
+            get(urlEqualTo("/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Ffile?ref=sha1")).willReturn(
+                aResponse().withStatus(404)
+            )
+        );
+
+        GitlabFetcher fetcher = fetcher(10_000);
+
+        assertThatThrownBy(fetcher::fetch)
+            .isInstanceOf(FetcherException.class)
+            .hasCauseInstanceOf(FetcherException.class)
+            .cause()
+            .isNotInstanceOf(ExecutionException.class);
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void should_fail_fast_when_connection_is_closed_while_reading_response() {
+        wiremock.stubFor(
+            get(urlEqualTo("/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Ffile?ref=sha1")).willReturn(
+                aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)
+            )
+        );
+
+        GitlabFetcher fetcher = fetcher(10_000);
+
+        assertThatThrownBy(fetcher::fetch).isInstanceOf(FetcherException.class);
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void should_fail_when_connection_stalls_while_reading_body() {
+        wiremock.stubFor(
+            get(urlEqualTo("/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Ffile?ref=sha1")).willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withBody("{\"content\": \"R3Jhdml0ZWUuaW8gaXMgYXdlc29tZSE=\"}")
+                    .withChunkedDribbleDelay(20, 20_000)
+            )
+        );
+
+        GitlabFetcher fetcher = fetcher(500);
+
+        assertThatThrownBy(fetcher::fetch).isInstanceOf(FetcherException.class);
+    }
+
+    private GitlabFetcher fetcher(int timeoutMs) {
+        GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
+        config.setFilepath("/path/to/file");
+        config.setProject("project");
+        config.setNamespace("namespace");
+        config.setGitlabUrl(wiremock.baseUrl() + "/api/v4");
+        config.setBranchOrTag("sha1");
+        config.setPrivateToken("token");
+        config.setApiVersion(ApiVersion.V4);
+
+        GitlabFetcher fetcher = new GitlabFetcher(config);
+        ReflectionTestUtils.setField(fetcher, "vertx", vertx);
+        ReflectionTestUtils.setField(fetcher, "mapper", new ObjectMapper());
+        ReflectionTestUtils.setField(fetcher, "httpClientTimeout", timeoutMs);
+        return fetcher;
+    }
+}

--- a/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcher_FetchTest.java
+++ b/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcher_FetchTest.java
@@ -55,8 +55,9 @@ class GitlabFetcher_FetchTest {
     @Test
     public void shouldNotFetchWithoutContent() throws FetcherException {
         wiremock.stubFor(
-            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1"))
-                .willReturn(aResponse().withStatus(200).withBody("{\"key\": \"value\"}"))
+            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1")).willReturn(
+                aResponse().withStatus(200).withBody("{\"key\": \"value\"}")
+            )
         );
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
         config.setFilepath("/path/to/file");
@@ -77,8 +78,9 @@ class GitlabFetcher_FetchTest {
     @Test
     public void shouldNotFetchEmptyBody() throws Exception {
         wiremock.stubFor(
-            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1"))
-                .willReturn(aResponse().withStatus(200))
+            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1")).willReturn(
+                aResponse().withStatus(200)
+            )
         );
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
         config.setFilepath("/path/to/file");
@@ -98,8 +100,9 @@ class GitlabFetcher_FetchTest {
     @Test
     public void shouldThrowExceptionIfContentNotBase64() throws Exception {
         wiremock.stubFor(
-            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1"))
-                .willReturn(aResponse().withStatus(200).withBody("{\"content\": \"not base64 content\"}"))
+            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1")).willReturn(
+                aResponse().withStatus(200).withBody("{\"content\": \"not base64 content\"}")
+            )
         );
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
         config.setFilepath("/path/to/file");
@@ -120,8 +123,9 @@ class GitlabFetcher_FetchTest {
         String encoded = Base64.getEncoder().encodeToString(content.getBytes());
 
         wiremock.stubFor(
-            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1"))
-                .willReturn(aResponse().withStatus(200).withBody("{\"content\": \"" + encoded + "\"}"))
+            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1")).willReturn(
+                aResponse().withStatus(200).withBody("{\"content\": \"" + encoded + "\"}")
+            )
         );
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
         config.setFilepath("/path/to/file");
@@ -150,8 +154,9 @@ class GitlabFetcher_FetchTest {
         String encoded = Base64.getEncoder().encodeToString(content.getBytes());
 
         wiremock.stubFor(
-            get(urlEqualTo("/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Ffile?ref=sha1"))
-                .willReturn(aResponse().withStatus(200).withBody("{\"content\": \"" + encoded + "\"}"))
+            get(urlEqualTo("/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Ffile?ref=sha1")).willReturn(
+                aResponse().withStatus(200).withBody("{\"content\": \"" + encoded + "\"}")
+            )
         );
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
         config.setFilepath("/path/to/file");
@@ -180,8 +185,9 @@ class GitlabFetcher_FetchTest {
         String encoded = Base64.getEncoder().encodeToString(content.getBytes());
 
         wiremock.stubFor(
-            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1"))
-                .willReturn(aResponse().withStatus(401).withBody("{\n" + "  \"message\": \"401 Unauthorized\"\n" + "}"))
+            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/files?file_path=/path/to/file&ref=sha1")).willReturn(
+                aResponse().withStatus(401).withBody("{\n" + "  \"message\": \"401 Unauthorized\"\n" + "}")
+            )
         );
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
         config.setFilepath("/path/to/file");

--- a/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcher_TreeTest.java
+++ b/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcher_TreeTest.java
@@ -56,8 +56,7 @@ public class GitlabFetcher_TreeTest {
                 urlEqualTo(
                     "/api/v3/projects/namespace%2Fproject/repository/tree?path=path%2Fto%2Ffile&ref=sha1&recursive=true&per_page=100"
                 )
-            )
-                .willReturn(aResponse().withStatus(200).withBody("{\"key\": \"value\"}"))
+            ).willReturn(aResponse().withStatus(200).withBody("{\"key\": \"value\"}"))
         );
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
         config.setFilepath("/path/to/file");
@@ -82,8 +81,7 @@ public class GitlabFetcher_TreeTest {
                 urlEqualTo(
                     "/api/v3/projects/namespace%2Fproject/repository/tree?path=path%2Fto%2Ffile&ref=sha1&recursive=true&per_page=100"
                 )
-            )
-                .willReturn(aResponse().withStatus(200))
+            ).willReturn(aResponse().withStatus(200))
         );
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
         config.setFilepath("/path/to/file");
@@ -108,8 +106,7 @@ public class GitlabFetcher_TreeTest {
                 urlEqualTo(
                     "/api/v3/projects/namespace%2Fproject/repository/tree?path=path%2Fto%2Ffile&ref=sha1&recursive=true&per_page=100"
                 )
-            )
-                .willReturn(aResponse().withStatus(401).withBody("{\n" + "  \"message\": \"401 Unauthorized\"\n" + "}"))
+            ).willReturn(aResponse().withStatus(401).withBody("{\n" + "  \"message\": \"401 Unauthorized\"\n" + "}"))
         );
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
         config.setFilepath("/path/to/file");
@@ -135,8 +132,7 @@ public class GitlabFetcher_TreeTest {
                 urlEqualTo(
                     "/api/v3/projects/namespace%2Fproject/repository/tree?path=path%2Fto%2Ffile&ref=sha1&recursive=true&per_page=100"
                 )
-            )
-                .willReturn(aResponse().withStatus(200).withFixedDelay(100).withBody(treeResponse))
+            ).willReturn(aResponse().withStatus(200).withFixedDelay(100).withBody(treeResponse))
         );
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
         config.setFilepath("/path/to/file");
@@ -159,8 +155,9 @@ public class GitlabFetcher_TreeTest {
     @Test
     public void shouldTreeWithEmptyPath() throws Exception {
         wiremock.stubFor(
-            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/tree?path=&ref=sha1&recursive=true&per_page=100"))
-                .willReturn(aResponse().withStatus(200).withBody(treeResponse))
+            get(urlEqualTo("/api/v3/projects/namespace%2Fproject/repository/tree?path=&ref=sha1&recursive=true&per_page=100")).willReturn(
+                aResponse().withStatus(200).withBody(treeResponse)
+            )
         );
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
         config.setFilepath(null);
@@ -180,36 +177,35 @@ public class GitlabFetcher_TreeTest {
         assertThat(tree).contains("/path/to/filepath/swagger.yml", "/path/to/filepath/subdir/doc.md");
     }
 
-    private final String treeResponse =
-        """
-                    [
-                        {
-                            "id": "f15543ee98011810baba7886e443684ff34460bb",
-                            "name": "subdir",
-                            "type": "tree",
-                            "path": "path/to/filepath/subdir",
-                            "mode": "040000"
-                        },
-                        {
-                            "id": "f15543ee98011810baba7886e443684ff34460bb",
-                            "name": "subsubdir",
-                            "type": "tree",
-                            "path": "path/to/filepath/subdir/subsubdir",
-                            "mode": "040000"
-                        },
-                        {
-                            "id": "8fbc3cda5e3d58d102ab2661543e0769fd21ba5b",
-                            "name": "swagger.yml",
-                            "type": "blob",
-                            "path": "path/to/filepath/swagger.yml",
-                            "mode": "100644"
-                        },
-                        {
-                            "id": "7ec4657417aae9959960d21046dac9d251ba569e",
-                            "name": "doc.md",
-                            "type": "blob",
-                            "path": "path/to/filepath/subdir/doc.md",
-                            "mode": "100644"
-                        }
-                    ]""";
+    private final String treeResponse = """
+        [
+            {
+                "id": "f15543ee98011810baba7886e443684ff34460bb",
+                "name": "subdir",
+                "type": "tree",
+                "path": "path/to/filepath/subdir",
+                "mode": "040000"
+            },
+            {
+                "id": "f15543ee98011810baba7886e443684ff34460bb",
+                "name": "subsubdir",
+                "type": "tree",
+                "path": "path/to/filepath/subdir/subsubdir",
+                "mode": "040000"
+            },
+            {
+                "id": "8fbc3cda5e3d58d102ab2661543e0769fd21ba5b",
+                "name": "swagger.yml",
+                "type": "blob",
+                "path": "path/to/filepath/swagger.yml",
+                "mode": "100644"
+            },
+            {
+                "id": "7ec4657417aae9959960d21046dac9d251ba569e",
+                "name": "doc.md",
+                "type": "blob",
+                "path": "path/to/filepath/subdir/doc.md",
+                "mode": "100644"
+            }
+        ]""";
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14628

**Description**

Migrate the fetcher to Vert.x 5 to fix `NoSuchMethodError`: `HttpClientOptions.setMaxPoolSize(int)` on APIM 4.12 (runtime upgraded to Vert.x 5): bump to gravitee-bom 9.x and replace the removed pool/request APIs with `PoolOptions` + `request.send()`, mirroring the **gravitee-fetcher-http** 3.0.0 migration.

Breaking change: the plugin now requires an APIM runtime on Vert.x 5 (≥ 4.12). Also switches logging to @CustomLog (separate commit).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-fix-vertx-fetcher-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-gitlab/3.0.0-fix-vertx-fetcher-SNAPSHOT/gravitee-fetcher-gitlab-3.0.0-fix-vertx-fetcher-SNAPSHOT.zip)
  <!-- Version placeholder end -->
