### PR TITLE
fix: throw explicit resource not found error and harmonize filepath docs

### DIFF
--- a/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/gitlab/GitlabFetcher.java
@@ -24,6 +24,7 @@ import io.gravitee.fetcher.api.FetcherConfiguration;
 import io.gravitee.fetcher.api.FetcherException;
 import io.gravitee.fetcher.api.FilesFetcher;
 import io.gravitee.fetcher.api.Resource;
+import io.gravitee.fetcher.api.ResourceNotFoundException;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.utils.NodeUtils;
 import io.vertx.core.Future;
@@ -288,9 +289,30 @@ public class GitlabFetcher implements FilesFetcher {
             throw new FetcherException("Unable to fetch Gitlab content (" + ie.getMessage() + ")", ie);
         } catch (Exception ex) {
             Throwable cause = ex instanceof ExecutionException && ex.getCause() != null ? ex.getCause() : ex;
+            if (cause instanceof ResourceNotFoundException resourceNotFoundException) {
+                throw resourceNotFoundException;
+            }
             log.error(cause.getMessage(), cause);
             throw new FetcherException("Unable to fetch Gitlab content (" + cause.getMessage() + ")", cause);
         }
+    }
+
+    private String buildNotFoundMessage(String url) {
+        String ref = gitlabFetcherConfiguration.getBranchOrTag() == null || gitlabFetcherConfiguration.getBranchOrTag().trim().isEmpty()
+            ? "master"
+            : gitlabFetcherConfiguration.getBranchOrTag().trim();
+        return (
+            "Unable to fetch file '" +
+            gitlabFetcherConfiguration.getFilepath() +
+            "' from GitLab project '" +
+            gitlabFetcherConfiguration.getNamespace() +
+            "/" +
+            gitlabFetcherConfiguration.getProject() +
+            "' (ref: " +
+            ref +
+            "): resource not found. Requested URL: " +
+            url
+        );
     }
 
     private CompletableFuture<Buffer> fetchContent(String url) throws Exception {
@@ -368,6 +390,8 @@ public class GitlabFetcher implements FilesFetcher {
     private Future<Buffer> handleResponse(String url, HttpClientResponse response) {
         if (response.statusCode() == HttpStatusCode.OK_200) {
             return response.body();
+        } else if (response.statusCode() == HttpStatusCode.NOT_FOUND_404) {
+            return Future.failedFuture(new ResourceNotFoundException(buildNotFoundMessage(url), null));
         } else {
             return Future.failedFuture(
                 new FetcherException(

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -39,7 +39,7 @@
         },
         "filepath": {
             "title": "Filepath",
-            "description": "The path to the file to fetch (e.g. /docs/main/README.md)",
+            "description": "The path to the file to fetch (e.g. docs/main/README.md)",
             "type": "string"
         },
         "privateToken": {

--- a/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcher_FilepathNormalizationTest.java
+++ b/src/test/java/io/gravitee/fetcher/gitlab/GitlabFetcher_FilepathNormalizationTest.java
@@ -17,26 +17,23 @@ package io.gravitee.fetcher.gitlab;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import io.gravitee.fetcher.api.FetcherException;
+import io.gravitee.fetcher.api.Resource;
+import io.gravitee.fetcher.api.ResourceNotFoundException;
 import io.vertx.core.Vertx;
-import java.util.concurrent.ExecutionException;
+import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-/**
- * @author GraviteeSource Team
- */
-class GitlabFetcherTest {
+class GitlabFetcher_FilepathNormalizationTest {
 
     @RegisterExtension
     static WireMockExtension wiremock = WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
@@ -54,56 +51,46 @@ class GitlabFetcherTest {
     }
 
     @Test
-    void should_expose_original_cause_instead_of_async_wrapper_when_fetch_fails() {
+    void should_fetch_content_when_filepath_has_no_leading_slash() throws Exception {
+        stubContent();
+
+        GitlabFetcher fetcher = fetcher("path/to/file");
+        Resource resource = fetcher.fetch();
+
+        assertThat(resource).isNotNull();
+        assertThat(new String(resource.getContent().readAllBytes())).isEqualTo("Gravitee.io is awesome!");
+    }
+
+    @Test
+    void should_throw_resource_not_found_with_filepath_project_and_ref_when_response_is_404() {
         wiremock.stubFor(
-            get(urlEqualTo("/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Ffile?ref=sha1")).willReturn(
-                aResponse().withStatus(500)
+            get(urlEqualTo("/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Funknown?ref=sha1")).willReturn(
+                aResponse().withStatus(404)
             )
         );
 
-        GitlabFetcher fetcher = fetcher(10_000);
+        GitlabFetcher fetcher = fetcher("/path/to/unknown");
 
         assertThatThrownBy(fetcher::fetch)
-            .isInstanceOf(FetcherException.class)
-            .hasCauseInstanceOf(FetcherException.class)
-            .cause()
-            .isNotInstanceOf(ExecutionException.class);
+            .isInstanceOf(ResourceNotFoundException.class)
+            .hasMessageContaining("Unable to fetch file '/path/to/unknown'")
+            .hasMessageContaining("namespace/project")
+            .hasMessageContaining("ref: sha1")
+            .hasNoCause();
     }
 
-    @Test
-    @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    void should_fail_fast_when_connection_is_closed_while_reading_response() {
+    private void stubContent() {
+        String encodedContent = Base64.getEncoder().encodeToString("Gravitee.io is awesome!".getBytes());
         wiremock.stubFor(
             get(urlEqualTo("/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Ffile?ref=sha1")).willReturn(
-                aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)
+                aResponse().withStatus(200).withBody("{\"content\": \"" + encodedContent + "\"}")
             )
         );
-
-        GitlabFetcher fetcher = fetcher(10_000);
-
-        assertThatThrownBy(fetcher::fetch).isInstanceOf(FetcherException.class);
     }
 
-    @Test
-    @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    void should_fail_when_connection_stalls_while_reading_body() {
-        wiremock.stubFor(
-            get(urlEqualTo("/api/v4/projects/namespace%2Fproject/repository/files/path%2Fto%2Ffile?ref=sha1")).willReturn(
-                aResponse()
-                    .withStatus(200)
-                    .withBody("{\"content\": \"R3Jhdml0ZWUuaW8gaXMgYXdlc29tZSE=\"}")
-                    .withChunkedDribbleDelay(20, 20_000)
-            )
-        );
-
-        GitlabFetcher fetcher = fetcher(500);
-
-        assertThatThrownBy(fetcher::fetch).isInstanceOf(FetcherException.class);
-    }
-
-    private GitlabFetcher fetcher(int timeoutMs) {
+    private GitlabFetcher fetcher(String filepath) {
         GitlabFetcherConfiguration config = new GitlabFetcherConfiguration();
-        config.setFilepath("/path/to/file");
+        config.setFilepath(filepath);
         config.setProject("project");
         config.setNamespace("namespace");
         config.setGitlabUrl(wiremock.baseUrl() + "/api/v4");
@@ -114,7 +101,7 @@ class GitlabFetcherTest {
         GitlabFetcher fetcher = new GitlabFetcher(config);
         ReflectionTestUtils.setField(fetcher, "vertx", vertx);
         ReflectionTestUtils.setField(fetcher, "mapper", new ObjectMapper());
-        ReflectionTestUtils.setField(fetcher, "httpClientTimeout", timeoutMs);
+        ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
         return fetcher;
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PORTAL-55

**Description**

Documentation fetchers handled the filepath leading slash inconsistently (one form worked, the other failed with an opaque error, and the rule differed between plugins). Align this plugin with the others: accept the filepath with or without a leading slash, and raise an explicit not-found error (file, repository, ref) when the file does not exist.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-fix-doc-filepath-normalization-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-gitlab/3.0.1-fix-doc-filepath-normalization-SNAPSHOT/gravitee-fetcher-gitlab-3.0.1-fix-doc-filepath-normalization-SNAPSHOT.zip)
  <!-- Version placeholder end -->
